### PR TITLE
Fixed loading race condition

### DIFF
--- a/renderers/_init.js
+++ b/renderers/_init.js
@@ -55,6 +55,9 @@ socket.element.addEventListener("welcome", event => {
 	// Do the same for the bomb icon
 	document.getElementById("bomb").style.transform = `scale(${event.data.config.radar.playerDotScale}) translate(-50%, -50%)`
 })
+if(socket.native && socket.native.readyNumber === 1){
+	socket.native.send("requestWelcome");
+}
 
 window.addEventListener("DOMContentLoaded", () => {
 	// If not electron (browser)

--- a/renderers/_socket.js
+++ b/renderers/_socket.js
@@ -4,6 +4,7 @@
 // listen for.
 
 let socket = {
+	native: null,
 	connected: false,
 	connect: () =>  {
 		// Check if we're in electron
@@ -45,8 +46,10 @@ let socket = {
 
 		function attachEvents(websocket) {
 			// Called when the socket is started
+			socket.native = websocket;
 			websocket.onopen = () => {
 				socket.connected = true
+				websocket.send("requestWelcome")
 			}
 
 			// Called when the server has pushed a message to us

--- a/socket.js
+++ b/socket.js
@@ -22,17 +22,21 @@ for (let renderer of renderers) {
 // When a new connection is established
 wss.on("connection", ws => {
 	// Send a packet so the client has a config and knows what scripts to load
-	ws.send(JSON.stringify({
-		type: "welcome",
-		data: {
-			scripts: scripts,
-			config: {
-				browser: config.browser,
-				radar: config.radar,
-				autozoom: config.autozoom
-			}
+	ws.on("message", message => {
+		if(message === "requestWelcome"){
+			ws.send(JSON.stringify({
+				type: "welcome",
+				data: {
+					scripts: scripts,
+					config: {
+						browser: config.browser,
+						radar: config.radar,
+						autozoom: config.autozoom
+					}
+				}
+			}))
 		}
-	}))
+	})
 })
 
 // When a packet needs to be sent


### PR DESCRIPTION
The issue was that sometimes we send the "welcome" message to the WebSocket, but even though socket was connected, frontend hadn't started listening yet for that message.

Solution to it is:
We don't send "welcome" message on the connection. Instead, frontend requests the message only whenit's connected, and only once it's requested config and scripts are sent. Additionaly in _init.js we check if the connection has been made before the listener fired and we do "just-to-be-sure" welcome request.